### PR TITLE
Leave script + ancestor checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Automatically execution of `.autoxsh` xonsh script after entering (cd-ing) into the directory.
 
-[![PyPi version](https://img.shields.io/pypi/v/xonsh-autoxsh.svg?style=flat-square)](https://pypi.python.org/pypi/xonsh-autoxsh) [![PyPi license](https://img.shields.io/pypi/l/xonsh-autoxsh.svg?style=flat-square)](https://pypi.python.org/pypi/xonsh-autoxsh) [![PyPi license](https://img.shields.io/pypi/pyversions/xonsh-autoxsh.svg?style=flat-square)](https://pypi.python.org/pypi/xonsh-autoxsh)  
+[![PyPi version](https://img.shields.io/pypi/v/xonsh-autoxsh.svg?style=flat-square)](https://pypi.python.org/pypi/xonsh-autoxsh) [![PyPi license](https://img.shields.io/pypi/l/xonsh-autoxsh.svg?style=flat-square)](https://pypi.python.org/pypi/xonsh-autoxsh) [![Python version](https://img.shields.io/pypi/pyversions/xonsh-autoxsh.svg?style=flat-square)](https://pypi.python.org/pypi/xonsh-autoxsh)  
 
 ## Installation
 ```python
@@ -18,6 +18,11 @@ echo 'xontrib load autoxsh' >> ~/.xonshrc
 - `.leave.xsh` - executed after leaving a directory
 
 Execution order: `(olddir)/.leave.xsh`, `(newdir)/.autoxsh`, `(newdir)/.enter.xsh`.
+
+## Environment variables
+
+- `$AXSH_CHECK_PARENTS` - enable checking the parents of the old / new directory for leave / enter files
+- `$AXSH_DEBUG` - prints debug information
 
 ## Use cases
 
@@ -58,6 +63,26 @@ echo "vox activate myenv" > /tmp/dir/.enter.xsh
 cd /tmp/dir
 # Activated "myenv".
 ```
+
+### Parent check mode
+
+```python
+mkdir -p /tmp/dir1/sdir1
+mkdir -p /tmp/dir2
+echo "hello dir1" > /tmp/dir1/.enter.xsh
+echo "bye dir1" > /tmp/dir1/.leave.xsh
+echo "hello sdir1" > /tmp/dir1/sdir1/.enter.xsh
+echo "hello dir2" > /tmp/dir1/.erter.xsh
+cd /tmp/dir1/sdir1
+# (authorization ignored)
+# hello dir1
+# hello sdir1
+cd /tmp/dir2
+# bye dir1
+# hello dir2
+```
+
+Please note that `.autoxsh` is ignored in parent check mode, only `.enter.xsh` and `.leave.xsh` scripts are executed.
 
 ## Links 
 * This package is the part of [ergopack](https://github.com/anki-code/xontrib-ergopack) - the pack of ergonomic xontribs.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ cd /tmp/dir
 ### Run xonsh script after leaving a directory
 
 ```python
+mkdir -p /tmp/dir
 echo "print('bye!')" > /tmp/dir/.leave.xsh
 cd /tmp/dir
 cd /

--- a/README.md
+++ b/README.md
@@ -11,19 +11,40 @@ pip install xonsh-autoxsh
 echo 'xontrib load autoxsh' >> ~/.xonshrc
 ```
 
+## Autoxsh files
+
+- `.autoxsh` - executed after entering a directory
+- `.enter.xsh` - same as `.autoxsh` but with `.xsh` extension
+- `.leave.xsh` - executed after leaving a directory
+
+Execution order: `(olddir)/.leave.xsh`, `(newdir)/.autoxsh`, `(newdir)/.enter.xsh`.
+
 ## Use cases
 
 ### Run xonsh script after entering (cd-ing) into the directory
 
 ```python
 mkdir -p /tmp/dir
-echo "print('it works!')" > /tmp/dir/.autoxsh
+echo "print('it works!')" > /tmp/dir/.enter.xsh
 cd /tmp/dir
-# Unauthorized ".autoxsh" file found in this directory. Authorize and invoke? (y/n/ignore): y
+# Unauthorized ".enter.xsh" file found in this directory. Authorize and invoke? (y/n/ignore): y
 # it works!
 cd /
 cd /tmp/dir
 # it works!
+```
+
+### Run xonsh script after leaving a directory
+
+```python
+echo "print('bye!')" > /tmp/dir/.leave.xsh
+cd /tmp/dir
+cd /
+# Unauthorized ".leave.xsh" file found in this directory. Authorize and invoke? (y/n/ignore): y
+# bye!
+cd /tmp/dir
+cd /
+# bye!
 ```
 
 ### Activate Python virtual environment with vox
@@ -32,7 +53,7 @@ cd /tmp/dir
 xontrib load vox
 vox new myenv
 mkdir -p /tmp/dir
-echo "vox activate myenv" > /tmp/dir/.autoxsh
+echo "vox activate myenv" > /tmp/dir/.enter.xsh
 cd /tmp/dir
 # Activated "myenv".
 ```

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         'Topic :: Desktop Environment',
         'Topic :: System :: Shells',
         'Topic :: System :: System Shells',
-]
+    ]
 )

--- a/xontrib/autoxsh.xsh
+++ b/xontrib/autoxsh.xsh
@@ -2,21 +2,29 @@ import os
 _AUTHORIZED_FILE = os.path.join(__xonsh__.env['XONSH_DATA_DIR'], 'xontrib_autoxsh_authorized.txt')
 _IGNORE_FILE = os.path.join(__xonsh__.env['XONSH_DATA_DIR'], 'xontrib_autoxsh_ignore.txt')
 
+
 @events.on_chdir
 def auto_cd(olddir, newdir, **kw):
-    target = os.path.join(newdir, '.autoxsh')
+    for tdir, file in [(olddir, '.leave.xsh'), (newdir, '.autoxsh'), (newdir, '.enter.xsh')]:
+        run_script(tdir, file)
+
+
+def run_script(tdir, file):
+    target = os.path.join(tdir, file)
     target = os.path.expanduser(target)
-    has_envfile = os.path.isfile(target)
-    if not has_envfile:
+    if not os.path.isfile(target):
         return
-    # Deal with authorization
+
+    # deal with authorization
     open(_AUTHORIZED_FILE, 'a').close()
     open(_IGNORE_FILE, 'a').close()
+
     # check whether dir is ignored
     with open(_IGNORE_FILE, 'r') as ignore_file:
         for line in ignore_file.readlines():
             if target in line:
                 return
+
     # check whether dir is authorized
     authorized = False
     with open(_AUTHORIZED_FILE, 'r') as trust_file:
@@ -24,8 +32,9 @@ def auto_cd(olddir, newdir, **kw):
             if target in line:
                 authorized = True
                 break
+
     if not authorized:
-        printx('{YELLOW}Unauthorized ".autoxsh" file found in this directory. Authorize and invoke? (y/n/ignore): {RESET}', end='')
+        printx(f'{{YELLOW}}Unauthorized "{file}" file found in this directory. Authorize and invoke? (y/n/ignore): {{RESET}}', end='')
         to_authorize = input().lower()
         if "y" in to_authorize:
             authorized = True
@@ -34,8 +43,10 @@ def auto_cd(olddir, newdir, **kw):
         if "ignore" in to_authorize:
             with open(_IGNORE_FILE, 'a') as ignore_file:
                 ignore_file.write('{}\n'.format(target))
+
     if authorized:
         source @(target)
+
 
 __all__ = ()
 __version__ = 0.4

--- a/xontrib/autoxsh.xsh
+++ b/xontrib/autoxsh.xsh
@@ -67,7 +67,7 @@ def run_script(tdir, file):
                 break
 
     if not authorized:
-        printx(f'{{BRIGHT_YELLOW}}[axsh]{{RESET}} Unauthorized "{{BRIGHT_RED}}{file}{{RESET}}" file found in this directory. Authorize and invoke? (y/n/ignore): ', end='')
+        printx(f'{{INTENSE_YELLOW}}[axsh]{{RESET}} Unauthorized "{{INTENSE_RED}}{file}{{RESET}}" file found in this directory. Authorize and invoke? (y/n/ignore): ', end='')
         to_authorize = input().lower()
         if "y" in to_authorize:
             authorized = True


### PR DESCRIPTION
Added support for directory leaving (`.leave.xsh`) and recursive ancestor enter/leave checking.

Closes #10 .